### PR TITLE
[WIP] workflows: npm publish

### DIFF
--- a/workflow-templates/js-tests.properties.json
+++ b/workflow-templates/js-tests.properties.json
@@ -1,6 +1,6 @@
 {
-    "name": "Publish an Invenio JavaScript Module",
-    "description": "Publish an Invenio module to NPM",
+    "name": "NPM publishing",
+    "description": "JavaScript package publishing to NPM",
     "iconName": "npm-icon",
     "categories": [
         "JavaScript"

--- a/workflow-templates/js-tests.yml
+++ b/workflow-templates/js-tests.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  Tests:
+
+    runs-on: ubuntu-20.04
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Install & Build
+      run: |
+        npm ci
+        npm run build
+
+    - name: Test
+      run: npm test

--- a/workflow-templates/js-tests.yml
+++ b/workflow-templates/js-tests.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ $default-branch ]
   pull_request:
-    branches: [ master ]
+    branches: [ $default-branch ]
 
 jobs:
   Tests:
@@ -26,7 +26,7 @@ jobs:
 
     - name: Install & Build
       run: |
-        npm ci
+        npm install
         npm run build
 
     - name: Test

--- a/workflow-templates/npm-icon.svg
+++ b/workflow-templates/npm-icon.svg
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" x="0px" y="0px" width="540px" height="210px" viewBox="0 0 18 7">
+<path fill="#CB3837" d="M0,0h18v6H9v1H5V6H0V0z M1,5h2V2h1v3h1V1H1V5z M6,1v5h2V5h2V1H6z M8,2h1v2H8V2z M11,1v4h2V2h1v3h1V2h1v3h1V1H11z"/>
+<polygon fill="#FFFFFF" points="1,5 3,5 3,2 4,2 4,5 5,5 5,1 1,1 "/>
+<path fill="#FFFFFF" d="M6,1v5h2V5h2V1H6z M9,4H8V2h1V4z"/>
+<polygon fill="#FFFFFF" points="11,1 11,5 13,5 13,2 14,2 14,5 15,5 15,2 16,2 16,5 17,5 17,1 "/>
+</svg>

--- a/workflow-templates/npm-publish.properties.json
+++ b/workflow-templates/npm-publish.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "NPM publishing",
+    "description": "JavaScript package publishing to NPM",
+    "iconName": "npm-icon",
+    "categories": [
+        "JavaScript"
+    ],
+    "filePatterns": [
+        "^package.json"
+    ]
+}

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -1,4 +1,4 @@
-name: NPM Publish
+name: Publish
 
 on:
   push:
@@ -16,15 +16,14 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          # Adapt the version to the minimal required
           node-version: 14
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Install and Build
         run: |
-          npm ci
+          npm install
           npm run build
-
       - name: Publish on NPM
-        run: npm publish
-          env:
-            NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/workflow-templates/npm-publish.yml
+++ b/workflow-templates/npm-publish.yml
@@ -1,0 +1,30 @@
+name: NPM Publish
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  Publish:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          # Adapt the version to the minimal required
+          node-version: 14
+
+      - name: Install and Build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Publish on NPM
+        run: npm publish
+          env:
+            NODE_AUTH_TOKEN: ${{secrets.npm_token}}

--- a/workflow-templates/pypi-publish.properties.json
+++ b/workflow-templates/pypi-publish.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "Publish an Invenio Module",
+    "name": "Publish an Invenio Python Module",
     "description": "Publish an Invenio module to Python Package Index.",
     "iconName": "pypi-icon",
     "categories": [

--- a/workflow-templates/pypi-publish.yml
+++ b/workflow-templates/pypi-publish.yml
@@ -1,4 +1,4 @@
-name: PyPI Publish
+name: Publish
 
 on:
   push:


### PR DESCRIPTION
**DO NOT MERGE**

By default the action published with tag `latest`, but I understand we want a version (the actual tag, e.g. v1.0.0). This is partially available under `${{ github.ref }}` in the format `refs/tags/v1.0.0`. Would need to be somehow parsed e.g. [like here](https://github.community/t/how-to-get-just-the-tag-name/16241/11). 